### PR TITLE
DIET-2 Unable to call Recetas API

### DIFF
--- a/src/main/java/com/tortu/api/configuration/JaxRSConfig.java
+++ b/src/main/java/com/tortu/api/configuration/JaxRSConfig.java
@@ -13,6 +13,7 @@ public class JaxRSConfig extends ResourceConfig {
         log.info("Initializing Rest Services...");
         packages("com.tortu.api");
         register(UsuarioRestService.class);
+        register(RecetaRestService.class);
         register(CategoriaIngredienteRestService.class);
         register(IngredienteRestService.class);
         register(DietaUsuarioRestService.class);

--- a/src/main/java/com/tortu/api/rest/restservices/RecetaRestService.java
+++ b/src/main/java/com/tortu/api/rest/restservices/RecetaRestService.java
@@ -24,7 +24,7 @@ import java.util.List;
  * Controller de la entidad de Recetas
  */
 @Service
-@Path("/v1/recetas")
+@Path("api/v1/recetas")
 public class RecetaRestService {
 
     @Autowired

--- a/src/main/java/com/tortu/api/rest/restservices/RecetaRestService.java
+++ b/src/main/java/com/tortu/api/rest/restservices/RecetaRestService.java
@@ -24,7 +24,7 @@ import java.util.List;
  * Controller de la entidad de Recetas
  */
 @Service
-@Path("api/v1/recetas")
+@Path("/api/v1/recetas")
 public class RecetaRestService {
 
     @Autowired

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -12,7 +12,7 @@ security.user.name=admin
 security.user.password=secret
 
 # Configuracion de BD
-#db.url=jdbc:mariadb://localhost:3306/dietapp
+db.url=jdbc:mariadb://localhost:3306/dietapp
 db.username=root
 db.password=root
 db.driver-class-name=org.mariadb.jdbc.Driver


### PR DESCRIPTION
Ticket Jira: https://gina-dietapp.atlassian.net/jira/software/projects/DIET/boards/1?selectedIssue=DIET-2
When calling any of the /api/v1/recetas API, we are not able to get a valid response. We are getting a 404 not found error for all the API calls that have /recetas on the URL.
AC: none
Resolved: path fixed in REST service. Recetas API now working
![image](https://user-images.githubusercontent.com/29048102/101552634-2b014500-3981-11eb-82e6-e165a9d34e24.png)
