### PR TITLE
DIET-5 update ingrediente failing

### DIFF
--- a/src/main/java/com/tortu/api/daos/IngredienteDao.java
+++ b/src/main/java/com/tortu/api/daos/IngredienteDao.java
@@ -10,7 +10,7 @@ public interface IngredienteDao extends GenericDao<Ingrediente, Integer> {
     public static final String SAVE =
             "insert into ingrediente (nombre, id_categoria_ingrediente) values ('test', ?)";
     public static final String UPDATE =
-            "update ingredientes set nombre = ?, id_categoria_ingrediente = ? where id_ingrediente = ?";
+            "update ingrediente set nombre = ?, id_categoria_ingrediente = ? where id_ingrediente = ?";
     public static final String DELETE =
             "delete from ingrediente where id_ingrediente = ?";
 }


### PR DESCRIPTION
Jira Ticket: https://gina-dietapp.atlassian.net/browse/DIET-5
When trying to update an existing ingrrediente, we are getting a 500 internal server error, and getting this message: {
    "errorMessage": "PreparedStatementCallback; bad SQL grammar [update ingredientes set nombre = ?, id_categoria_ingrediente = ? where id_ingrediente = ?]; nested exception is java.sql.SQLSyntaxErrorException: (conn=22) Table 'dietapp.ingredientes' doesn't exist",
    "cause": "(conn=22) Table 'dietapp.ingredientes' doesn't exist"
}
AC: 
We should be able to update the ingrediente data.

Resolved:
DB table name fixed
